### PR TITLE
tests(smoke): Fix the path used in the smoke tests base script

### DIFF
--- a/tests/smoke/base.sh
+++ b/tests/smoke/base.sh
@@ -4,6 +4,7 @@ set -e
 
 PATH_ORI=${PATH}
 CONDA_PATH=$(cd $(dirname $(which conda)) && cd .. && pwd)
+PROJECT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd ../.. && pwd )"
 
 export PATH="${CONDA_PATH}/condabin:${CONDA_PATH}/bin:$PATH"
 echo "[II] included conda to the PATH"
@@ -12,7 +13,7 @@ ENV_NAME=osl-python-package
 
 rm -rf "/tmp/${ENV_NAME}"
 
-cookiecutter --output-dir /tmp/ --no-input . ${1}="${2}"
+cookiecutter --output-dir /tmp/ --no-input ${PROJECT_PATH} ${1}="${2}"
 cd "/tmp/${ENV_NAME}"
 
 mamba env create --file conda/dev.yaml --force


### PR DESCRIPTION
## Pull Request description
<!-- Describe the purpose of your PR and the changes you have made. -->
This PR aims to fix the path used by the cookiecutter call in the smoke test base script.

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solving issue #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
